### PR TITLE
Update `:paused` content

### DIFF
--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.paused
 
 {{CSSRef}}
 
-The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes)  represents an element that is capable of being "played" or "paused", when that element is "paused" (i.e. not "playing"). (This includes both an explicit "paused" state, and other non-playing states like "loaded, hasn't been activated yet", etc.)
+The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element that is capable of being "played" or "paused", when that element is "paused" (i.e. not "playing"). This includes both an explicit "paused" state, and other non-playing states like "loaded, hasn't been activated yet", etc.
 
 A resource is paused if the user explicitly paused it, or if it is in a non-activated state.
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.paused
 
 {{CSSRef}}
 
-The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being "played" or "paused", when that element is "paused".
+The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes)  represents an element that is capable of being "played" or "paused", when that element is "paused" (i.e. not "playing"). (This includes both an explicit "paused" state, and other non-playing states like "loaded, hasn't been activated yet", etc.)
 
 A resource is paused if the user explicitly paused it, or if it is in a non-activated state.
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.paused
 
 {{CSSRef}}
 
-The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector represents an element that is playable, such as {{htmlelement("audio")}} or  {{htmlelement("video")}},  when that element is "paused" (i.e. not "playing").
+The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector represents an element that is playable, such as {{htmlelement("audio")}} or {{htmlelement("video")}}, when that element is "paused" (i.e. not "playing").
 
 A resource is paused if the user explicitly paused it, or if it is in a non-activated or other non-playing state, like "loaded, hasn't been activated yet."
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -9,7 +9,7 @@ browser-compat: css.selectors.paused
 
 The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element that is capable of being "played" or "paused", when that element is "paused" (i.e. not "playing"). This includes both an explicit "paused" state, and other non-playing states like "loaded, hasn't been activated yet", etc.
 
-A resource is paused if the user explicitly paused it, or if it is in a non-activated state.
+A resource is paused if the user explicitly paused it, or if it is in a non-activated or other non-playing state, like "loaded, hasn't been activated yet."
 
 ## Syntax
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.paused
 
 {{CSSRef}}
 
-The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element that is capable of being "played" or "paused", when that element is "paused" (i.e. not "playing"). This includes both an explicit "paused" state, and other non-playing states like "loaded, hasn't been activated yet", etc.
+The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector represents an element that is playable, such as {{htmlelement("audio")}} or  {{htmlelement("video")}},  when that element is "paused" (i.e. not "playing").
 
 A resource is paused if the user explicitly paused it, or if it is in a non-activated or other non-playing state, like "loaded, hasn't been activated yet."
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The content in the original text:

> will match an audio, video, or similar resource that is capable of being "played" or "paused" 

should refer to the resource status pseudo-class rather than the `:paused` pseudo-class. The wording here might be incorrect. I have consulted the [specification](https://www.w3.org/TR/selectors-4/#selectordef-paused) of this pseudo-class and incorporated the description from the specification here.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
